### PR TITLE
Refactor away the "Frozen" state of the timer

### DIFF
--- a/src/Timer.elm
+++ b/src/Timer.elm
@@ -1,7 +1,7 @@
 module Timer exposing
     ( Timer(..)
-    , activeTimerSetTo
     , expiredTimer
+    , stoppedTimerSetTo
     , tick
     , timeRemainingInSeconds
     )
@@ -10,13 +10,14 @@ import TypedTime exposing (TypedTime, seconds)
 
 
 type Timer
-    = ActiveTimer { timeRemaining : TypedTime }
+    = ActiveTimer TypedTime
+    | StoppedTimer TypedTime
     | ExpiredTimer
 
 
-activeTimerSetTo : TypedTime -> Timer
-activeTimerSetTo timeRemaining =
-    ActiveTimer { timeRemaining = timeRemaining }
+stoppedTimerSetTo : TypedTime -> Timer
+stoppedTimerSetTo timeRemaining =
+    StoppedTimer timeRemaining
 
 
 expiredTimer : Timer
@@ -27,13 +28,16 @@ expiredTimer =
 tick : Timer -> Timer
 tick timer =
     case timer of
-        ActiveTimer properties ->
+        StoppedTimer _ ->
+            timer
+
+        ActiveTimer timeRemaining ->
             let
                 newTimeRemaining =
-                    TypedTime.sub properties.timeRemaining (seconds 1)
+                    TypedTime.sub timeRemaining (seconds 1)
             in
             if TypedTime.gt newTimeRemaining (seconds 0) then
-                ActiveTimer { properties | timeRemaining = newTimeRemaining }
+                ActiveTimer newTimeRemaining
 
             else
                 ExpiredTimer
@@ -45,7 +49,10 @@ tick timer =
 timeRemainingInSeconds : Timer -> Int
 timeRemainingInSeconds timer =
     case timer of
-        ActiveTimer { timeRemaining } ->
+        StoppedTimer timeRemaining ->
+            TypedTime.toSeconds timeRemaining |> floor
+
+        ActiveTimer timeRemaining ->
             TypedTime.toSeconds timeRemaining |> floor
 
         ExpiredTimer ->

--- a/tests/TimerEngineTests.elm
+++ b/tests/TimerEngineTests.elm
@@ -1,15 +1,15 @@
 module TimerEngineTests exposing (allTests)
 
 import Expect
-import Fuzz exposing (..)
-import Test exposing (..)
-import Timer exposing (..)
+import Fuzz exposing (intRange)
+import Test exposing (Test, describe, fuzz, test)
+import Timer exposing (Timer, expiredTimer, tick, timeRemainingInSeconds)
 import TypedTime
 
 
 newActiveTimerSetInSecondsAsInt : Int -> Timer
 newActiveTimerSetInSecondsAsInt =
-    toFloat >> TypedTime.seconds >> activeTimerSetTo
+    toFloat >> TypedTime.seconds >> Timer.ActiveTimer
 
 
 allTests : Test


### PR DESCRIPTION
One way I like to move things is to combine separate flags into multiple states of the same thing.
A timer now intrinsically represent three possible states:
- Active (it is ticking down)
- Stopped (it has a time remaining and was ticking down, but is
  currently paused) (maybe this should be called `Paused`, oh well)
- Expired (remaining time is zero)

I think this goes along the lines of "make it impossible to represent illegal states". Now it is impossible to represent e.g. a `Frozen` state with an `Expired` timer. This was possible before but didn't make any sense in the domain.

What I most like about this, is that by pattern matching on a tuple, functions like `setTimerRunning` become really obvious:

```elm
setTimerRunning model on =
    case ( model.timer, on ) of
        ( ActiveTimer remainingTime, False ) ->
            ( { model | timer = StoppedTimer remainingTime }, Cmd.none )

        ( StoppedTimer remainingTime, True ) ->
            ( { model | timer = ActiveTimer remainingTime }, Cmd.none )

        ( _, _ ) ->
            ( model, Cmd.none )
```

What do you think? Oh, and happy new year 🎈 